### PR TITLE
修复32位系统Hash计算错误的BUG

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,19 @@ b'h(\x03\x1b\xd8\xf0\x06\x10\xdc\xe1\rrk\x03\x19\x00\x00\x00\x00\x00'
 >>> print(base64.b64encode(h.digest()))
 b'aCgDG9jwBhDc4Q1yawMZAAAAAAA='
 ```
+
+## 安装方法(entware环境)
+
+- 下载解压原文件
+```
+wget --no-check-certificate -O /opt/home/quickxorhash.zip https://github.com/shawze/quickxorhash/archive/refs/heads/master.zip
+unzip /opt/home/quickxorhash.zip 
+cd /opt/home/quickxorhash-master 
+```
+
+step2: 安装编译
+```
+opkg install gcc
+opkg install python3-dev
+python setup.py install
+```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ unzip /opt/home/quickxorhash.zip
 cd /opt/home/quickxorhash-master 
 ```
 
-step2: 安装编译
+- 安装编译
 ```
 opkg install gcc
 opkg install python3-dev

--- a/quickxorhash.c
+++ b/quickxorhash.c
@@ -1,9 +1,12 @@
-/* This file is part of quickxorhash and distributed under the terms of the
+﻿/* This file is part of quickxorhash and distributed under the terms of the
  * MIT license. See COPYING.
  */
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
+#include <locale.h>
+
 
 #include "quickxorhash.h"
 
@@ -36,7 +39,7 @@ qxh_update( qxhash *q, uint8_t *data, size_t len )
 {
     size_t  i, j, iterations;
     size_t  cell_index, next_cell;
-    int     cell_bits, cell_bitpos;
+    size_t     cell_bits, cell_bitpos;
     uint8_t new_byte;
 
     cell_index = q->shifted / 64;
@@ -82,7 +85,7 @@ qxh_finalize( qxhash *q )
 {
     size_t      b_data_len;
     uint8_t     *b_data = NULL;
-    long long int      b_len_len;
+    uint64_t      b_len_len;
     uint8_t     *b_len = NULL;
     size_t      i;
 
@@ -117,4 +120,27 @@ qxh_free( qxhash *q )
         free( q->cell );
         free( q );
     }
+}
+
+
+char *
+qxh_file(qxhash *q, const char * filename) {
+    FILE *         fp;
+    uint8_t        buf[ 4096 ];
+    size_t         len;
+
+    setlocale(LC_ALL,"");
+    fp = fopen(filename, "rb");
+//    fp = _wfopen(filename, L"rb");
+
+    if (!fp) {
+        printf("Failed to open %s\n",filename);
+        return NULL;
+    }
+    while ((len = fread(buf, 1, 4096, fp)) > 0) {
+        qxh_update(q, buf, len);
+    }
+    char * hash_code = qxh_finalize(q);
+    return hash_code;
+
 }

--- a/quickxorhash.c
+++ b/quickxorhash.c
@@ -82,7 +82,7 @@ qxh_finalize( qxhash *q )
 {
     size_t      b_data_len;
     uint8_t     *b_data = NULL;
-    size_t      b_len_len;
+    long long int      b_len_len;
     uint8_t     *b_len = NULL;
     size_t      i;
 
@@ -93,6 +93,7 @@ qxh_finalize( qxhash *q )
     memcpy( b_data, q->cell, b_data_len );
 
     b_len_len = sizeof( q->len );
+	// b_len_len = 8;
     if (( b_len = calloc( 1, b_len_len )) == NULL ) {
         goto error;
     }

--- a/quickxorhash.h
+++ b/quickxorhash.h
@@ -7,7 +7,9 @@ struct qxhash {
     size_t      width;
     size_t      shift;
     size_t      shifted;
-    long long int      len;
+    uint64_t      len;
+    // long long int      len;
+
     size_t      cell_len;
     uint64_t    *cell;
 };
@@ -18,5 +20,6 @@ qxhash  *qxh_new( void );
 void    qxh_update( qxhash *, uint8_t *, size_t );
 char    *qxh_finalize( qxhash * );
 void    qxh_free( qxhash * );
+char    *qxh_file(qxhash *, const char * filename);
 
 #endif /* QUICKXORHASH_H */

--- a/quickxorhash.h
+++ b/quickxorhash.h
@@ -7,7 +7,7 @@ struct qxhash {
     size_t      width;
     size_t      shift;
     size_t      shifted;
-    size_t      len;
+    long long int      len;
     size_t      cell_len;
     uint64_t    *cell;
 };

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup, Extension
 
 setup(
     name='quickxorhash',
-    version = '1.0.2',
+    version = '1.0.5',
     description='Quick XOR hash function for OneDrive for Business',
     long_description_markdown_filename='README.md',
     keywords='quickxorhash onedrive',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup, Extension
 
 setup(
     name='quickxorhash',
-    version = '1.0.5',
+    version = '1.0.5.2',
     description='Quick XOR hash function for OneDrive for Business',
     long_description_markdown_filename='README.md',
     keywords='quickxorhash onedrive',


### PR DESCRIPTION
1. 修复32位系统Hash计算错误的BUG, 变量b_len_len、len类型由size_t更改为long long int；
2. 更新版本号到1.0.5；
